### PR TITLE
Using getters to update plugin editor param values

### DIFF
--- a/capstone_v2/ClarinetModel/Source/PluginEditor.cpp
+++ b/capstone_v2/ClarinetModel/Source/PluginEditor.cpp
@@ -26,12 +26,13 @@ clarinetPluginAudioProcessorEditor::clarinetPluginAudioProcessorEditor (clarinet
 void clarinetPluginAudioProcessorEditor::setSliders() {
    addAndMakeVisible(&freqSlider);
    freqSlider.setLookAndFeel((&otherLookAndFeel));
-   freqSlider.setSliderStyle(juce::Slider::LinearVertical);
-   freqSlider.setValue(kFreqDEF);
-
    // range: E3 to C7
    // TODO: only allow semitones
    freqSlider.setRange(146.832, 2093.005);
+   freqSlider.setValue(audioProcessor.getFreq());
+   freqSlider.setSliderStyle(juce::Slider::LinearVertical);
+
+
    // update the pressure value whenever the slider changes
    freqSlider.onValueChange = [this] {
       std::cout << "freqSlider: " << freqSlider.getValue() <<std::endl;
@@ -44,7 +45,7 @@ void clarinetPluginAudioProcessorEditor::setSliders() {
    addAndMakeVisible(&envAttackSlider);
    envAttackSlider.setSliderStyle(juce::Slider::LinearVertical);
    envAttackSlider.setTextBoxStyle(juce::Slider::TextEntryBoxPosition::NoTextBox, false, 0, 0);
-   envAttackSlider.setValue(kFreqDEF);
+   envAttackSlider.setValue(audioProcessor.getEnvAttack());
    envAttackSlider.setRange(1.0, 30.0);
    envAttackSlider.onValueChange = [this] {
       std::cout << "envAttackSlider: " << envAttackSlider.getValue() <<std::endl;
@@ -55,7 +56,7 @@ void clarinetPluginAudioProcessorEditor::setSliders() {
    addAndMakeVisible(&bendSlider);
    bendSlider.setSliderStyle(juce::Slider::LinearVertical);
    bendSlider.setTextBoxStyle(juce::Slider::TextEntryBoxPosition::NoTextBox, false, 0, 0);
-   bendSlider.setValue(kBendDEF);
+   bendSlider.setValue(audioProcessor.getBend());
    bendSlider.setRange(-2, 2);
    bendSlider.onValueChange = [this] {
       std::cout << "bendSlider: " << bendSlider.getValue() <<std::endl;
@@ -66,8 +67,8 @@ void clarinetPluginAudioProcessorEditor::setSliders() {
 
    addAndMakeVisible(&vibratoFreqSlider);
    vibratoFreqSlider.setSliderStyle(juce::Slider::LinearVertical);
+   vibratoFreqSlider.setValue(audioProcessor.getVibratoFreq());
    vibratoFreqSlider.setRange(0.0, 10.0);
-   vibratoFreqSlider.setValue(kVibratoFreqDEF);
    vibratoFreqSlider.setTextBoxStyle(juce::Slider::TextEntryBoxPosition::NoTextBox, false, 0, 0);
    // update the value whenever the slider changes
    vibratoFreqSlider.onValueChange = [this] {
@@ -78,8 +79,8 @@ void clarinetPluginAudioProcessorEditor::setSliders() {
 
    addAndMakeVisible(&vibratoGainSlider);
    vibratoGainSlider.setSliderStyle(juce::Slider::LinearVertical);
+   vibratoGainSlider.setValue(audioProcessor.getVibratoGain());
    vibratoGainSlider.setRange(0.0, 1.0);
-   vibratoGainSlider.setValue(kVibratoGainDEF);
    vibratoGainSlider.setTextBoxStyle(juce::Slider::TextEntryBoxPosition::NoTextBox, false, 0, 0);
    // update the value whenever the slider changes
    vibratoGainSlider.onValueChange = [this] {
@@ -90,8 +91,8 @@ void clarinetPluginAudioProcessorEditor::setSliders() {
 
    addAndMakeVisible(&reedStiffnessSlider);
    reedStiffnessSlider.setSliderStyle(juce::Slider::LinearVertical);
+   reedStiffnessSlider.setValue(audioProcessor.getReedStiffness());
    reedStiffnessSlider.setRange(0.0, 1.0);
-   reedStiffnessSlider.setValue(kReedStiffDEF);
    reedStiffnessSlider.setTextBoxStyle(juce::Slider::TextEntryBoxPosition::NoTextBox, false, 0, 0);
    // update the value whenever the slider changes
    reedStiffnessSlider.onValueChange = [this] {
@@ -102,8 +103,8 @@ void clarinetPluginAudioProcessorEditor::setSliders() {
 
    addAndMakeVisible(&bellOpeningSlider);
    bellOpeningSlider.setSliderStyle(juce::Slider::LinearVertical);
+   bellOpeningSlider.setValue(audioProcessor.getBellOpening());
    bellOpeningSlider.setRange(0.0, 1.0);
-   bellOpeningSlider.setValue(kBellOpeningDEF);
    bellOpeningSlider.setTextBoxStyle(juce::Slider::TextEntryBoxPosition::NoTextBox, false, 0, 0);
    // update the value whenever the slider changes
    bellOpeningSlider.onValueChange = [this] {
@@ -115,7 +116,7 @@ void clarinetPluginAudioProcessorEditor::setSliders() {
    addAndMakeVisible(&outGainSlider);
    outGainSlider.setSliderStyle(juce::Slider::LinearVertical);
    outGainSlider.setRange(0.0, 1.0);
-   outGainSlider.setValue(kOutGainDEF);
+   outGainSlider.setValue(audioProcessor.getOutGain());
    outGainSlider.setTextBoxStyle(juce::Slider::TextEntryBoxPosition::NoTextBox, false, 0, 0);
    // update the value whenever the slider changes
    outGainSlider.onValueChange = [this] {
@@ -171,10 +172,6 @@ void clarinetPluginAudioProcessorEditor::setLabels() {
    outGainLabel.attachToComponent (&outGainSlider, false);
    outGainLabel.setJustificationType(juce::Justification::bottom);
 
-//   addAndMakeVisible(&gateLabel);
-//   outGainLabel.setText ("Gate", juce::dontSendNotification);
-//   outGainLabel.attachToComponent (&gateButton, false);
-//   outGainLabel.setJustificationType(juce::Justification::right);
 }
 
 
@@ -218,12 +215,10 @@ void clarinetPluginAudioProcessorEditor::resized()
    vibratoFreqSlider.setBounds(leftGroup.removeFromLeft (sliderWidth));
    vibratoGainSlider.setBounds(leftGroup.removeFromLeft (sliderWidth));
    envAttackSlider.setBounds(leftGroup.removeFromLeft (sliderWidth));
-//   breathCutoffSlider.setBounds (leftGroup.removeFromLeft (sliderWidth));
-//   breathGainSlider.setBounds(leftGroup.removeFromLeft (sliderWidth));
 
    auto rightGroup = area.removeFromRight(400);
    rightGroup = rightGroup.removeFromTop(200);
-   // TODO: centre
+
    clarinetLenSlider.setBounds(rightGroup.removeFromRight(sliderWidth));
    bellOpeningSlider.setBounds(rightGroup.removeFromRight(sliderWidth));
    reedStiffnessSlider.setBounds(rightGroup.removeFromRight(sliderWidth));

--- a/capstone_v2/ClarinetModel/Source/PluginProcessor.cpp
+++ b/capstone_v2/ClarinetModel/Source/PluginProcessor.cpp
@@ -111,6 +111,16 @@ void clarinetPluginAudioProcessor::prepareToPlay (double sampleRate, int samples
       outputs[channel] = new float[samplesPerBlock];
    }
 
+   setFreq(kFreqDEF);
+   setBend(kBendDEF);
+   setEnvAttack(kEnvDEF);
+   setPressure(kPressureDEF);
+   setVibratoFreq(kVibratoFreqDEF);
+   setVibratoGain(kVibratoGainDEF);
+   setReedStiffness(kReedStiffDEF);
+   setBellOpening(kBellOpeningDEF);
+   setOutGain(kOutGainDEF);
+
 }
 
 void clarinetPluginAudioProcessor::releaseResources()
@@ -174,8 +184,7 @@ void clarinetPluginAudioProcessor::processBlock (juce::AudioBuffer<float>& buffe
     for (auto i = totalNumInputChannels; i < totalNumOutputChannels; ++i)
         buffer.clear (i, 0, buffer.getNumSamples());
 
-    // This is the place where you'd normally do the guts of your plugin's
-    // audio processing...
+
     // Make sure to reset the state if your inner loop is processing
     // the samples and the outer loop is handling the channels.
     // Alternatively, you can process the samples with the channels
@@ -183,7 +192,6 @@ void clarinetPluginAudioProcessor::processBlock (juce::AudioBuffer<float>& buffe
     for (int channel = 0; channel < totalNumInputChannels; ++channel)
     {
         auto* channelData = buffer.getWritePointer (channel);
-
         // ..do something to the data...
     }
 
@@ -290,24 +298,26 @@ void clarinetPluginAudioProcessor::setGate(bool gate)
 }
 
 //========================faust get parameter functions=============================
-//float clarinetPluginAudioProcessor::getPressure() {
-//   return fUI->getParamValue("/clarinet/blower/pressure");
-//}
-//float clarinetPluginAudioProcessor::getBreathGain() {
-//   return fUI->getParamValue("/clarinet/blower/breathGain");
-//}
-//float clarinetPluginAudioProcessor::getBreathCutoff() {
-//   return fUI->getParamValue("/clarinet/blower/breathCutoff");
-//}
+
+float clarinetPluginAudioProcessor::getFreq() {
+   return fUI->getParamValue("/clarinet/midi/freq");
+}
+
+float clarinetPluginAudioProcessor::getEnvAttack() {
+   return fUI->getParamValue("/clarinet/midi/envAttack");
+}
+
+float clarinetPluginAudioProcessor::getBend() {
+   return fUI->getParamValue("/clarinet/midi/bend");
+}
+
 float clarinetPluginAudioProcessor::getVibratoFreq() {
    return fUI->getParamValue("/clarinet/blower/vibratoFreq");
 }
 float clarinetPluginAudioProcessor::getVibratoGain() {
    return fUI->getParamValue("/clarinet/blower/vibratoGain");
 }
-//float clarinetPluginAudioProcessor::getTubeLength() {
-//   return fUI->getParamValue("/clarinet/clarinetModel/tubeLength");
-//}
+
 float clarinetPluginAudioProcessor::getReedStiffness() {
    return fUI->getParamValue("/clarinet/otherParams/reedStiffness");
 }

--- a/capstone_v2/ClarinetModel/Source/PluginProcessor.h
+++ b/capstone_v2/ClarinetModel/Source/PluginProcessor.h
@@ -70,16 +70,7 @@ public:
     void setStateInformation (const void* data, int sizeInBytes) override;
 
    //===========faust parameter functions==============================
-  /* **0**: `/clarinet/blower/pressure`
-  * **1**: `/clarinet/blower/breathGain`
-  * **2**: `/clarinet/blower/breathCutoff`
-  * **3**: `/clarinet/blower/vibratoFreq`
-  * **4**: `/clarinet/blower/vibratoGain`
-  * **5**: `/clarinet/clarinetModel/tubeLength`
-  * **6**: `/clarinet/clarinetModel/reedStiffness`
-  * **7**: `/clarinet/clarinetModel/bellOpening`
-  * **8**: `/clarinet/clarinetModel/outGain`
-   **/
+
    void setPressure(float pressure);
    void setBreathGain(float breathGain);
    void setBreathCutoff(float breathCutoff);
@@ -97,6 +88,9 @@ public:
    void setOutGain(float outGain);
    void setGate(bool gate);
 
+  float getFreq();
+  float getEnvAttack();
+  float getBend();
   float getPressure();
   float getBreathGain();
   float getBreathCutoff();
@@ -106,7 +100,19 @@ public:
   float getReedStiffness();
   float getBellOpening();
   float getOutGain();
-
+   //============================default values=============================//
+   float kFreqDEF = 146.832;
+   float kEnvDEF = 1.0;
+   float kBendDEF = 0;
+   float kPressureDEF = 0.0;
+   float kBreathGainDEF = 0.1;
+   float kBreathCutoffDEF = 2000;
+   float kVibratoFreqDEF = 5.0;
+   float kVibratoGainDEF = 0.25;
+   float kClarinetLenDEF = 0.8;
+   float kReedStiffDEF = 0.5;
+   float kBellOpeningDEF = 0.5;
+   float kOutGainDEF = 0.0;
 private:
    // wrapped as unique ptrs so when it is time to delete them, we don't
    // need to do anything additionally. (new/delete called under the hood)


### PR DESCRIPTION
-instead of setting default slider param values inside constructor of audioEditor, place them inside prepareToPlay() in audioProcessor file
-used getters from audioProcessor in audioEditor constructor to ensure the param values don't reset back to default when plugin window is closed + reopened